### PR TITLE
add rest dumps for logged in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ See the [WordPress / Medusa / Gatsby Frontend repo](https://github.com/websuperg
 ### Development Update log
 (for my mental sanity)
 
+> add index page which dumps rest api data when you access posts, pages, categories, and tags while logged in (helpful for troubleshooting)
+>
 > add functions.php (style enqueue and menu), style.css (theme info), index.php (rest/redirect)
 >
 > modified readme to add better instructions

--- a/index.php
+++ b/index.php
@@ -1,7 +1,30 @@
 <?php
 if ( is_user_logged_in() ) {
-	echo 'REST GOES HERE';
-} else {
+
+  $rest_url = "/wp/v2/";
+  $url = "posts/"; // it is a nice fallback
+
+  // set up our url
+  if ( is_single() ) {
+    $url = $rest_url . "posts/" . get_the_ID();
+  } elseif ( is_page() ) {
+    $url = $rest_url . "pages/" . get_the_ID();
+  } elseif ( is_category() ){
+    $url = $rest_url . "categories/" . get_queried_object_id();
+  } elseif ( is_tag() ) {
+    $url = $rest_url . "tags/" . get_queried_object_id();
+  }
+
+  // do a rest request and dump the api data on to the screen
+  $request = new WP_REST_Request( 'GET', $url );
+  $response = rest_do_request( $request );
+  $server = rest_get_server();
+  $data = $server->response_to_data( $response, false );
+  print "<pre>";
+  print_r( $data );
+  print "</pre>";
+
+} else { // if you're not logged in, you get redirected to the actual front end
 	wp_redirect( 'https://wordpress.org/plugins/wp-gatsby/' );
   exit;
 }


### PR DESCRIPTION
The idea of this is to dump out the api data on the front end so it's easier to troubleshoot development of the gatsby app.